### PR TITLE
chore: s/OpenTelemetry/Instrumentation Score/ in the footer

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -24,7 +24,7 @@ describe('Footer Component', () => {
 
   it('includes the community message', () => {
     render(<Footer />)
-    expect(screen.getByText(/Built with ❤️ by the OpenTelemetry community/)).toBeInTheDocument()
+    expect(screen.getByText(/Built with ❤️ by the Instrumentation Score community/)).toBeInTheDocument()
     expect(screen.getByText(/better instrumentation quality assessment/)).toBeInTheDocument()
   })
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
         </div>
 
         <div className="mt-8 pt-8 border-t border-slate-800 text-center text-slate-500">
-          <p>Built with ❤️ by the OpenTelemetry community for better instrumentation quality assessment.</p>
+          <p>Built with ❤️ by the Instrumentation Score community for better instrumentation quality assessment.</p>
         </div>
       </div>
     </footer>

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -29,6 +29,6 @@ describe('Index Page', () => {
 
   it('includes community-related content', () => {
     render(<Index />)
-    expect(screen.getByText(/OpenTelemetry community/)).toBeInTheDocument()
+    expect(screen.getByText(/Instrumentation Score community/)).toBeInTheDocument()
   })
 }) 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated footer and related tests to display "Built with ❤️ by the Instrumentation Score community" instead of referencing the OpenTelemetry community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->