### PR TITLE
chore: update slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ To deploy updates:
 
 ### Get Involved
 
-We welcome contributions from the OpenTelemetry community!
+We welcome all contributions!
 
-- 💬 **Join Discussion**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+- 💬 **Join Discussion**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C090FEG5R0F)
 - 🐛 **Report Issues**: 
   - **Specification Issues**: [instrumentation-score/spec Issues](https://github.com/instrumentation-score/spec/issues)
   - **Website Issues**: [This repository's issues]
@@ -132,4 +132,4 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](https:
 **🔗 Links:**
 - **Website**: [score.olly.garden](https://score.olly.garden)
 - **Specification**: [github.com/instrumentation-score/spec](https://github.com/instrumentation-score/spec)
-- **Community**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+- **Community**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C090FEG5R0F)

--- a/src/components/CallToAction.test.tsx
+++ b/src/components/CallToAction.test.tsx
@@ -51,7 +51,7 @@ describe('CallToAction Component', () => {
     render(<CallToAction />)
     const slackButton = screen.getByText('Join CNCF Slack')
     fireEvent.click(slackButton)
-    expect(mockWindowOpen).toHaveBeenCalledWith('https://cloud-native.slack.com/archives/C08U9NN1XBR', '_blank')
+    expect(mockWindowOpen).toHaveBeenCalledWith('https://cloud-native.slack.com/archives/C090FEG5R0F', '_blank')
   })
 
   it('has main get started button', () => {

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -58,7 +58,7 @@ export const CallToAction = () => {
               <Button 
                 variant="outline" 
                 className="w-full bg-purple-600 border-purple-600 text-white hover:bg-purple-700 hover:border-purple-700 hover:shadow-lg transition-all duration-300 font-semibold py-6 text-base"
-                onClick={() => window.open('https://cloud-native.slack.com/archives/C08U9NN1XBR', '_blank')}
+                onClick={() => window.open('https://cloud-native.slack.com/archives/C090FEG5R0F', '_blank')}
               >
                 Join CNCF Slack
                 <ArrowRight className="ml-2 w-4 h-4" />


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to generalize the invitation for contributions and updated the CNCF Slack channel URL in relevant sections.

- **Bug Fixes**
  - Updated the Slack channel URL in the "Join CNCF Slack" button to direct users to the correct channel.

- **Tests**
  - Adjusted tests to expect the updated Slack channel URL for the "CNCF Slack" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->