### PR TITLE
fix: correct score range from 10-100 to 0-100 in meta descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Instrumentation Score Specification</title>
-    <meta name="description" content="A standardized metric for assessing OpenTelemetry instrumentation quality. Numerical score from 10-100 providing objective feedback on telemetry best practices." />
+    <meta name="description" content="A standardized metric for assessing OpenTelemetry instrumentation quality. Numerical score from 0-100 providing objective feedback on telemetry best practices." />
     <meta name="author" content="Instrumentation Score Community" />
 
     <meta property="og:title" content="Instrumentation Score Specification" />
-    <meta property="og:description" content="A standardized metric for assessing OpenTelemetry instrumentation quality. Numerical score from 10-100 providing objective feedback on telemetry best practices." />
+    <meta property="og:description" content="A standardized metric for assessing OpenTelemetry instrumentation quality. Numerical score from 0-100 providing objective feedback on telemetry best practices." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/og-instrumentation-score.png" />
   </head>


### PR DESCRIPTION
## Summary
- Fixed HTML meta descriptions to use correct score range of 0-100 instead of 10-100
- Ensures consistency with the documented scoring system where Poor (0-49), Fair (50-69), Good (70-89), and Excellent (90-100)

## Test plan
- [x] Verify meta descriptions in `index.html` now show "0-100"
- [x] Confirm consistency with existing documentation and UI components
- [ ] Check that SEO meta tags display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected page metadata and Open Graph descriptions to show the valid score range as 0–100, ensuring previews and snippets display the accurate range and reducing user confusion.

* **Documentation**
  * Updated public-facing descriptions so search results, social cards, and marketing copy consistently reflect the 0–100 range. No functional or UI changes; improves clarity in external previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->